### PR TITLE
Percent 50

### DIFF
--- a/android/app/src/main/res/drawable/launch_background.xml
+++ b/android/app/src/main/res/drawable/launch_background.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!-- Modify this file to customize your launch splash screen -->
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
-    <item android:drawable="@android:color/white" />
+    <item android:drawable="@android:color/white"/>
 
     <!-- You can insert your own image assets here -->
-    <!-- <item>
+    <item>
         <bitmap
-            android:gravity="center"
-            android:src="@mipmap/launch_image" />
-    </item> -->
+                android:gravity="center"
+                android:src="@mipmap/ic_launcher"/>
+    </item>
 </layer-list>

--- a/lib/widgets/voip.dart
+++ b/lib/widgets/voip.dart
@@ -155,25 +155,30 @@ class _VoipConnectionState extends State<VoipConnection> {
             fit: BoxFit.fill,
           ),
         ),
-        Text(
-          "${entity.name} ${entity.surname}",
-          softWrap: true,
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            fontSize: 24.0,
-            fontWeight: FontWeight.w700,
-          ),
-        ),
-        (entity is PatientId)
-            ? Container()
-            : Text(
-          "Hearth and Brain Specialist",
-          textAlign: TextAlign.center,
-          style: TextStyle(
-            fontStyle: FontStyle.italic,
-            fontWeight: FontWeight.w400,
-            fontSize: 20.0,
-          ),
+        Column(
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            Text(
+              "${entity.name} ${entity.surname}",
+              softWrap: true,
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontSize: 24.0,
+                fontWeight: FontWeight.w700,
+              ),
+            ),
+            (entity is PatientId)
+                ? Container()
+                : Text(
+              "Hearth and Brain Specialist",
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                fontStyle: FontStyle.italic,
+                fontWeight: FontWeight.w400,
+                fontSize: 20.0,
+              ),
+            ),
+          ],
         ),
         (entity is PatientId)
             ? Row(

--- a/lib/widgets/voip.dart
+++ b/lib/widgets/voip.dart
@@ -143,108 +143,96 @@ class _VoipConnectionState extends State<VoipConnection> {
   Widget _testChildBuilder(entity) {
     // _invitePeer(context, entity.id, false),
     return Column(
+      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+      crossAxisAlignment: CrossAxisAlignment.center,
       children: <Widget>[
-        Padding(
-          padding: const EdgeInsets.only(top: 45.0),
-          child: ClipRRect(
-            borderRadius: BorderRadius.circular(50.0),
-            child: Image.network(
-              entity.profilePic,
-              width: 150,
-              height: 150,
-              fit: BoxFit.fill,
-            ),
+        ClipRRect(
+          borderRadius: BorderRadius.circular(50.0),
+          child: Image.network(
+            entity.profilePic,
+            width: 150,
+            height: 150,
+            fit: BoxFit.fill,
           ),
         ),
-        Padding(
-          padding: const EdgeInsets.only(top: 25.0),
-          child: Text(
-            "${entity.name} ${entity.surname}",
-            softWrap: true,
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: 24.0,
-              fontWeight: FontWeight.w700,
-            ),
+        Text(
+          "${entity.name} ${entity.surname}",
+          softWrap: true,
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontSize: 24.0,
+            fontWeight: FontWeight.w700,
           ),
         ),
         (entity is PatientId)
             ? Container()
             : Text(
-                "Hearth and Brain Specialist",
-                textAlign: TextAlign.center,
-                style: TextStyle(
-                  fontStyle: FontStyle.italic,
-                  fontWeight: FontWeight.w400,
-                  fontSize: 20.0,
+          "Hearth and Brain Specialist",
+          textAlign: TextAlign.center,
+          style: TextStyle(
+            fontStyle: FontStyle.italic,
+            fontWeight: FontWeight.w400,
+            fontSize: 20.0,
+          ),
+        ),
+        (entity is PatientId)
+            ? Row(
+          mainAxisAlignment: MainAxisAlignment.center,
+          crossAxisAlignment: CrossAxisAlignment.center,
+          children: <Widget>[
+            RaisedButton(
+              onPressed: () =>
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) =>
+                          DetailsPage(
+                            patient: entity,
+                          ),
+                    ),
+                  ),
+              child: Container(
+                width: 70.0,
+                height: 70.0,
+                child: Icon(
+                  Icons.dehaze,
+                  color: Colors.white,
                 ),
               ),
-        Padding(
-          padding: const EdgeInsets.only(top: 5.0),
-          child: (entity is PatientId)
-              ? Row(
-                  children: <Widget>[
-                    Padding(
-                      padding: const EdgeInsets.only(left: 15.0, top: 15.0),
-                      child: RaisedButton(
-                        onPressed: () => Navigator.push(
-                              context,
-                              MaterialPageRoute(
-                                builder: (context) => DetailsPage(
-                                      patient: entity,
-                                    ),
-                              ),
-                            ),
-                        child: Container(
-                          width: 70.0,
-                          height: 70.0,
-                          child: Icon(
-                            Icons.dehaze,
-                            color: Colors.white,
-                          ),
-                        ),
-                        shape: CircleBorder(),
-                        color: Colors.blue,
-                      ),
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(top: 15.0),
-                      child: RaisedButton(
-                        onPressed: isOnline
-                            ? () => _invitePeer(context, entity.id, false)
-                            : null,
-                        child: Container(
-                          width: 70.0,
-                          height: 70.0,
-                          child: Icon(
-                            Icons.call,
-                            color: Colors.white,
-                          ),
-                        ),
-                        shape: CircleBorder(),
-                        color: Colors.blue,
-                      ),
-                    ),
-                  ],
-                )
-              : Padding(
-                  padding: const EdgeInsets.only(top: 5.0),
-                  child: RaisedButton(
-                    onPressed: isOnline
-                        ? () => _invitePeer(context, entity.id, false)
-                        : null,
-                    child: Container(
-                      width: 70.0,
-                      height: 70.0,
-                      child: Icon(
-                        Icons.call,
-                        color: Colors.white,
-                      ),
-                    ),
-                    shape: CircleBorder(),
-                    color: Colors.blue,
-                  ),
+              shape: CircleBorder(),
+              color: Colors.blue,
+            ),
+            RaisedButton(
+              onPressed: isOnline
+                  ? () => _invitePeer(context, entity.id, false)
+                  : null,
+              child: Container(
+                width: 70.0,
+                height: 70.0,
+                child: Icon(
+                  Icons.call,
+                  color: Colors.white,
                 ),
+              ),
+              shape: CircleBorder(),
+              color: Colors.blue,
+            ),
+          ],
+        )
+            : RaisedButton(
+          onPressed: isOnline
+              ? () => _invitePeer(context, entity.id, false)
+              : null,
+          child: Container(
+            width: 70.0,
+            height: 70.0,
+            child: Icon(
+              Icons.call,
+              color: Colors.white,
+            ),
+          ),
+          shape: CircleBorder(),
+          color: Colors.blue,
         )
       ],
     );


### PR DESCRIPTION
# Brief
I know it's not cool compared to the previous PR's that have 20+ commits in them but this feature has to merged develop as soon as possible since any changes on VOIP class, *which will be RTC class*, will depend on this new structure. Also, we have android only splash image now. Please check #14 for the reason for android only change.

# Explanation
We had a spacing issue between buttons and entity information. When we use smaller screen sizes, buttons were causing overflow, so with these fixes, they won't bother us anymore.

# Test
I tested these changes on both Android Pixel emulator and Turkcell T70. There were no issues related to the flex.

![](https://gifimage.net/wp-content/uploads/2018/06/tired-anime-gif-12.gif)